### PR TITLE
use UID 1001 for the persistant volume mount to match initialization UID

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,10 @@ jobs:
       - setup_remote_docker:
           version: 17.06.0-ce
       - run:
+          name: Upgrade system packages (workaround - https://github.com/docker-library/docker/issues/72)
+          command: |
+            apk upgrade --no-cache
+      - run:
           name: Install dependencies
           command: |
             apk add --no-cache curl bash coreutils

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -36,6 +36,8 @@ items:
         labels:
           io.kompose.service: redis
       spec:
+        securityContext:
+          fsGroup: 1001        
         containers:
         - image: bitnami/redis:latest
           name: redis
@@ -67,4 +69,3 @@ items:
   status: {}
 kind: List
 metadata: {}
-

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -37,6 +37,7 @@ items:
           io.kompose.service: redis
       spec:
         securityContext:
+          runAsUser: 1001
           fsGroup: 1001        
         containers:
         - image: bitnami/redis:latest


### PR DESCRIPTION
This pull request addresses a filesystem permissions error.  Reference: https://github.com/bitnami/bitnami-docker-redis/issues/87