### PR TITLE
typo fixed: redis-slave instead of redis-secondary

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ services:
 Scale the number of slaves using:
 
 ```bash
-$ docker-compose scale redis-master=1 redis-secondary=3
+$ docker-compose scale redis-master=1 redis-slave=3
 ```
 
 The above command scales up the number of slaves to `3`. You can scale down in the same way.


### PR DESCRIPTION
scaling the slave instances with compose requires the _service name_. since this is "redis-slave" the `scale` parameter has to be also `redis-slave` and not `redis-secondary`

**Small Typo in README**

changed `redis-secondary` to `redis-slave`

**Benefits**

`docker-compose scale` will work with copy/paste.

**Possible drawbacks**

Less thinking on the user side needed ;-)


