### PR TITLE
disable bgsave

### DIFF
--- a/4.0/debian-9/rootfs/libredis.sh
+++ b/4.0/debian-9/rootfs/libredis.sh
@@ -83,6 +83,7 @@ redis_initialize() {
     # Enable AOF https://redis.io/topics/persistence#append-only-file
     # Leave default fsync (every second)
     redis_conf_set appendonly yes
+    redis_conf_set save ""
 
     if [ -n "$REDIS_PASSWORD" ]; then
         redis_conf_set requirepass "$REDIS_PASSWORD"

--- a/4.0/debian-9/rootfs/libredis.sh
+++ b/4.0/debian-9/rootfs/libredis.sh
@@ -83,6 +83,9 @@ redis_initialize() {
     # Enable AOF https://redis.io/topics/persistence#append-only-file
     # Leave default fsync (every second)
     redis_conf_set appendonly yes
+
+    # Disable RDB persistence, AOF persistence already enabled.
+    # Ref: https://redis.io/topics/persistence#interactions-between-aof-and-rdb-persistence
     redis_conf_set save ""
 
     if [ -n "$REDIS_PASSWORD" ]; then

--- a/4.0/ol-7/rootfs/libredis.sh
+++ b/4.0/ol-7/rootfs/libredis.sh
@@ -83,6 +83,7 @@ redis_initialize() {
     # Enable AOF https://redis.io/topics/persistence#append-only-file
     # Leave default fsync (every second)
     redis_conf_set appendonly yes
+    redis_conf_set save ""
 
     if [ -n "$REDIS_PASSWORD" ]; then
         redis_conf_set requirepass "$REDIS_PASSWORD"

--- a/4.0/ol-7/rootfs/libredis.sh
+++ b/4.0/ol-7/rootfs/libredis.sh
@@ -83,6 +83,9 @@ redis_initialize() {
     # Enable AOF https://redis.io/topics/persistence#append-only-file
     # Leave default fsync (every second)
     redis_conf_set appendonly yes
+
+    # Disable RDB persistence, AOF persistence already enabled.
+    # Ref: https://redis.io/topics/persistence#interactions-between-aof-and-rdb-persistence
     redis_conf_set save ""
 
     if [ -n "$REDIS_PASSWORD" ]; then


### PR DESCRIPTION
Disable redis save to dump.rdb

In /libredis.sh in the function redis_initialise() enable AOF bachpup
but the default configuration also enable snapshotting redis backups

Thus, in the default configuration, the radish saves data in two different formats simultaneously

redis documentation recommend disable snapshotting backup when aof backup enabled
https://redis.io/topics/persistence

disable snapshotting backups by setting the redis configuration
`save ""`

