### PR TITLE
Support custom arguments to be specified directly to entrypoint

### DIFF
--- a/4.0/debian-9/rootfs/entrypoint.sh
+++ b/4.0/debian-9/rootfs/entrypoint.sh
@@ -10,9 +10,8 @@ set -o pipefail
 
 print_welcome_page
 
-if [ "$*" = "/run.sh" ]; then
+if [[ "$*" = *"/run.sh"* ]]; then
     /setup.sh
 fi
-
 
 exec "$@"

--- a/4.0/debian-9/rootfs/run.sh
+++ b/4.0/debian-9/rootfs/run.sh
@@ -17,7 +17,7 @@ REDIS_EXTRA_FLAGS=${REDIS_EXTRA_FLAGS:-}
 
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
-    warn "REDIS_EXTRA_FLAGS is depredated. Please specify any extra-flag use 'run.sh $REDIS_EXTRA_FLAGS' as command instead"
+    warn "REDIS_EXTRA_FLAGS is deprecated. Please specify any extra-flag using 'run.sh $REDIS_EXTRA_FLAGS' as command instead"
     ARGS+=" $REDIS_EXTRA_FLAGS"
 fi
 

--- a/4.0/debian-9/rootfs/run.sh
+++ b/4.0/debian-9/rootfs/run.sh
@@ -12,11 +12,12 @@ eval "$(redis_env)"
 
 DAEMON=redis-server
 EXEC=$(which $DAEMON)
-ARGS="$REDIS_BASEDIR/etc/redis.conf --daemonize no"
+ARGS="$REDIS_BASEDIR/etc/redis.conf --daemonize no $@"
 REDIS_EXTRA_FLAGS=${REDIS_EXTRA_FLAGS:-}
 
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
+    warn "REDIS_EXTRA_FLAGS is depredated. Please specify any extra-flag use 'run.sh $REDIS_EXTRA_FLAGS' as command instead"
     ARGS+=" $REDIS_EXTRA_FLAGS"
 fi
 

--- a/4.0/ol-7/rootfs/entrypoint.sh
+++ b/4.0/ol-7/rootfs/entrypoint.sh
@@ -10,7 +10,7 @@ set -o pipefail
 
 print_welcome_page
 
-if [ "$*" = "/run.sh" ]; then
+if [[ "$*" = *"/run.sh"* ]]; then
     /setup.sh
 fi
 

--- a/4.0/ol-7/rootfs/run.sh
+++ b/4.0/ol-7/rootfs/run.sh
@@ -17,7 +17,7 @@ REDIS_EXTRA_FLAGS=${REDIS_EXTRA_FLAGS:-}
 
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
-    warn "REDIS_EXTRA_FLAGS is depredated. Please specify any extra-flag use 'run.sh $REDIS_EXTRA_FLAGS' as command instead"
+    warn "REDIS_EXTRA_FLAGS is deprecated. Please specify any extra-flag using 'run.sh $REDIS_EXTRA_FLAGS' as command instead"
     ARGS+=" $REDIS_EXTRA_FLAGS"
 fi
 

--- a/4.0/ol-7/rootfs/run.sh
+++ b/4.0/ol-7/rootfs/run.sh
@@ -12,11 +12,12 @@ eval "$(redis_env)"
 
 DAEMON=redis-server
 EXEC=$(which $DAEMON)
-ARGS="$REDIS_BASEDIR/etc/redis.conf --daemonize no"
+ARGS="$REDIS_BASEDIR/etc/redis.conf --daemonize no $@"
 REDIS_EXTRA_FLAGS=${REDIS_EXTRA_FLAGS:-}
 
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
+    warn "REDIS_EXTRA_FLAGS is depredated. Please specify any extra-flag use 'run.sh $REDIS_EXTRA_FLAGS' as command instead"
     ARGS+=" $REDIS_EXTRA_FLAGS"
 fi
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ services:
 
 ## Passing extra command-line flags to redis-server startup
 
-Passing extra command-line flags to the redis service command is possible through by adding them as arguments to *run.sh* script:
+Passing extra command-line flags to the redis service command is possible by adding them as arguments to *run.sh* script:
 
 ```bash
 $ docker run --name redis -e ALLOW_EMPTY_PASSWORD=yes bitnami/redis:latest /run.sh --maxmemory 100mb

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ services:
     command: /run.sh --maxmemory 100mb
 ```
 
+Refer to the [Redis documentation](https://redis.io/topics/config#passing-arguments-via-the-command-line) for the complete list of arguments.
+
 ## Setting the server password on first run
 
 Passing the `REDIS_PASSWORD` environment variable when running the image for the first time will set the Redis server password to the value of `REDIS_PASSWORD`.

--- a/README.md
+++ b/README.md
@@ -211,19 +211,16 @@ services:
 
 ## Passing extra command-line flags to redis-server startup
 
-Passing extra command-line flags to the redis service command is possible through the following env var:
-
-- `REDIS_EXTRA_FLAGS`: Flags to be appended to the startup command. No defaults
+Passing extra command-line flags to the redis service command is possible through by adding them as arguments to *run.sh* script:
 
 ```bash
-$ docker run --name redis -e ALLOW_EMPTY_PASSWORD=yes -e REDIS_EXTRA_FLAGS='--maxmemory 100mb' bitnami/redis:latest
+$ docker run --name redis -e ALLOW_EMPTY_PASSWORD=yes bitnami/redis:latest /run.sh --maxmemory 100mb
 ```
 
 or using Docker Compose:
 
 ```yaml
 version: '2'
-
 services:
   redis:
     image: 'bitnami/redis:latest'
@@ -232,6 +229,7 @@ services:
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
       - REDIS_EXTRA_FLAGS=--maxmemory 100mb
+    command: /run.sh --maxmemory 100mb
 ```
 
 ## Setting the server password on first run


### PR DESCRIPTION
### What this PR does / why we need it:

This PR allows the user to add its custom flags to *redis-server* by passing arguments directly to the **entrypoint.sh** instead of using the env. variable *REDIS_EXTRA_FLAGS*

### Which issue this PR fixes

fixes https://github.com/bitnami/bitnami-docker-redis/issues/117
