### PR TITLE
Avoid returning exitCode 1 when 'redis-default.conf' file exists

### DIFF
--- a/4.0/debian-9/rootfs/libredis.sh
+++ b/4.0/debian-9/rootfs/libredis.sh
@@ -309,7 +309,9 @@ redis_initialize() {
 
     # User injected custom configuration
     if [[ -e "$REDIS_BASEDIR/etc/redis.conf" ]]; then
-        [[ -e "$REDIS_BASEDIR/etc/redis-default.conf" ]] && rm "${REDIS_BASEDIR}/etc/redis-default.conf"
+        if [[ -e "$REDIS_BASEDIR/etc/redis-default.conf" ]]; then
+            rm "${REDIS_BASEDIR}/etc/redis-default.conf"
+        fi
     else
         debug "Ensuring expected directories/files exist..."
         for dir in "${REDIS_VOLUME}/data" "${REDIS_BASEDIR}/tmp" "${REDIS_LOGDIR}"; do

--- a/4.0/ol-7/rootfs/libredis.sh
+++ b/4.0/ol-7/rootfs/libredis.sh
@@ -309,7 +309,9 @@ redis_initialize() {
 
     # User injected custom configuration
     if [[ -e "$REDIS_BASEDIR/etc/redis.conf" ]]; then
-        [[ -e "$REDIS_BASEDIR/etc/redis-default.conf" ]] && rm "${REDIS_BASEDIR}/etc/redis-default.conf"
+        if [[ -e "$REDIS_BASEDIR/etc/redis-default.conf" ]]; then
+            rm "${REDIS_BASEDIR}/etc/redis-default.conf"
+        fi
     else
         debug "Ensuring expected directories/files exist..."
         for dir in "${REDIS_VOLUME}/data" "${REDIS_BASEDIR}/tmp" "${REDIS_LOGDIR}"; do

--- a/5.0/debian-9/rootfs/libredis.sh
+++ b/5.0/debian-9/rootfs/libredis.sh
@@ -309,7 +309,9 @@ redis_initialize() {
 
     # User injected custom configuration
     if [[ -e "$REDIS_BASEDIR/etc/redis.conf" ]]; then
-        [[ -e "$REDIS_BASEDIR/etc/redis-default.conf" ]] && rm "${REDIS_BASEDIR}/etc/redis-default.conf"
+        if [[ -e "$REDIS_BASEDIR/etc/redis-default.conf" ]]; then
+            rm "${REDIS_BASEDIR}/etc/redis-default.conf"
+        fi
     else
         debug "Ensuring expected directories/files exist..."
         for dir in "${REDIS_VOLUME}/data" "${REDIS_BASEDIR}/tmp" "${REDIS_LOGDIR}"; do

--- a/5.0/ol-7/rootfs/libredis.sh
+++ b/5.0/ol-7/rootfs/libredis.sh
@@ -309,7 +309,9 @@ redis_initialize() {
 
     # User injected custom configuration
     if [[ -e "$REDIS_BASEDIR/etc/redis.conf" ]]; then
-        [[ -e "$REDIS_BASEDIR/etc/redis-default.conf" ]] && rm "${REDIS_BASEDIR}/etc/redis-default.conf"
+        if [[ -e "$REDIS_BASEDIR/etc/redis-default.conf" ]]; then
+          rm "${REDIS_BASEDIR}/etc/redis-default.conf"
+        fi
     else
         debug "Ensuring expected directories/files exist..."
         for dir in "${REDIS_VOLUME}/data" "${REDIS_BASEDIR}/tmp" "${REDIS_LOGDIR}"; do


### PR DESCRIPTION
### Why we need this change?

The Bash script is returning a wrong exitCode when 'redis-default.conf' already exists during the initialisation. This PRs corrects that wrong behaviour.

### What issue(s) this PR fixes?

- fixes https://github.com/bitnami/bitnami-docker-redis/issues/123