### PR TITLE
Fix setting multiple flags

### DIFF
--- a/4.0/debian-9/rootfs/run.sh
+++ b/4.0/debian-9/rootfs/run.sh
@@ -21,7 +21,8 @@ args=("$REDIS_BASEDIR/etc/redis.conf" "--daemonize" "no" "$@")
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
     warn "REDIS_EXTRA_FLAGS is deprecated. Please specify any extra-flag using '/run.sh $REDIS_EXTRA_FLAGS' as command instead"
-    args+=($REDIS_EXTRA_FLAGS)
+    read -r -a envExtraFlags <<< "$REDIS_EXTRA_FLAGS"
+    args+=("${envExtraFlags[@]}")
 fi
 
 info "** Starting Redis **"

--- a/4.0/debian-9/rootfs/run.sh
+++ b/4.0/debian-9/rootfs/run.sh
@@ -21,7 +21,7 @@ args=("$REDIS_BASEDIR/etc/redis.conf" "--daemonize" "no" "$@")
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
     warn "REDIS_EXTRA_FLAGS is deprecated. Please specify any extra-flag using '/run.sh $REDIS_EXTRA_FLAGS' as command instead"
-    args+=("$REDIS_EXTRA_FLAGS")
+    args+=($REDIS_EXTRA_FLAGS)
 fi
 
 info "** Starting Redis **"

--- a/4.0/ol-7/rootfs/run.sh
+++ b/4.0/ol-7/rootfs/run.sh
@@ -21,7 +21,8 @@ args=("$REDIS_BASEDIR/etc/redis.conf" "--daemonize" "no" "$@")
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
     warn "REDIS_EXTRA_FLAGS is deprecated. Please specify any extra-flag using '/run.sh $REDIS_EXTRA_FLAGS' as command instead"
-    args+=($REDIS_EXTRA_FLAGS)
+    read -r -a envExtraFlags <<< "$REDIS_EXTRA_FLAGS"
+    args+=("${envExtraFlags[@]}")
 fi
 
 info "** Starting Redis **"

--- a/4.0/ol-7/rootfs/run.sh
+++ b/4.0/ol-7/rootfs/run.sh
@@ -21,7 +21,7 @@ args=("$REDIS_BASEDIR/etc/redis.conf" "--daemonize" "no" "$@")
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
     warn "REDIS_EXTRA_FLAGS is deprecated. Please specify any extra-flag using '/run.sh $REDIS_EXTRA_FLAGS' as command instead"
-    args+=("$REDIS_EXTRA_FLAGS")
+    args+=($REDIS_EXTRA_FLAGS)
 fi
 
 info "** Starting Redis **"

--- a/5.0/debian-9/rootfs/run.sh
+++ b/5.0/debian-9/rootfs/run.sh
@@ -21,7 +21,8 @@ args=("$REDIS_BASEDIR/etc/redis.conf" "--daemonize" "no" "$@")
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
     warn "REDIS_EXTRA_FLAGS is deprecated. Please specify any extra-flag using '/run.sh $REDIS_EXTRA_FLAGS' as command instead"
-    args+=($REDIS_EXTRA_FLAGS)
+    read -r -a envExtraFlags <<< "$REDIS_EXTRA_FLAGS"
+    args+=("${envExtraFlags[@]}")
 fi
 
 info "** Starting Redis **"

--- a/5.0/debian-9/rootfs/run.sh
+++ b/5.0/debian-9/rootfs/run.sh
@@ -21,7 +21,7 @@ args=("$REDIS_BASEDIR/etc/redis.conf" "--daemonize" "no" "$@")
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
     warn "REDIS_EXTRA_FLAGS is deprecated. Please specify any extra-flag using '/run.sh $REDIS_EXTRA_FLAGS' as command instead"
-    args+=("$REDIS_EXTRA_FLAGS")
+    args+=($REDIS_EXTRA_FLAGS)
 fi
 
 info "** Starting Redis **"

--- a/5.0/ol-7/rootfs/run.sh
+++ b/5.0/ol-7/rootfs/run.sh
@@ -21,7 +21,8 @@ args=("$REDIS_BASEDIR/etc/redis.conf" "--daemonize" "no" "$@")
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
     warn "REDIS_EXTRA_FLAGS is deprecated. Please specify any extra-flag using '/run.sh $REDIS_EXTRA_FLAGS' as command instead"
-    args+=($REDIS_EXTRA_FLAGS)
+    read -r -a envExtraFlags <<< "$REDIS_EXTRA_FLAGS"
+    args+=("${envExtraFlags[@]}")
 fi
 
 info "** Starting Redis **"

--- a/5.0/ol-7/rootfs/run.sh
+++ b/5.0/ol-7/rootfs/run.sh
@@ -21,7 +21,7 @@ args=("$REDIS_BASEDIR/etc/redis.conf" "--daemonize" "no" "$@")
 # configure extra command line flags
 if [[ -n "$REDIS_EXTRA_FLAGS" ]]; then
     warn "REDIS_EXTRA_FLAGS is deprecated. Please specify any extra-flag using '/run.sh $REDIS_EXTRA_FLAGS' as command instead"
-    args+=("$REDIS_EXTRA_FLAGS")
+    args+=($REDIS_EXTRA_FLAGS)
 fi
 
 info "** Starting Redis **"


### PR DESCRIPTION
**Description of the change**
When setting more than one extra flag since [this merge](https://github.com/bitnami/bitnami-docker-redis/pull/126/) the container crashes:
```
docker run -e REDIS_EXTRA_FLAGS="--maxmemory-policy noeviction --maxmemory 13000000" -e ALLOW_EMPTY_PASSWORD=yes --rm --name redis bitnami/redis
...
*** FATAL CONFIG FILE ERROR ***
Reading the configuration file, at line 1320
>>> 'maxmemory-policy noeviction --maxmemory 13000000'
Bad directive or wrong number of arguments
```
This minor change corrects the issue:
```
docker run -e REDIS_EXTRA_FLAGS="--maxmemory-policy noeviction --maxmemory 13000000" -e ALLOW_EMPTY_PASSWORD=yes --rm --name redis test
...
1:M 14 Nov 20:20:52.436 * Ready to accept connections
...
```
and:
```
docker exec redis redis-cli info |grep max
maxmemory:13000000
maxmemory_human:12.40M
maxmemory_policy:noeviction
```

**Benefits**
The container starts correctly with both 1 and many arguments.

- fixes https://github.com/bitnami/bitnami-docker-redis/issues/128
- fixes https://github.com/bitnami/charts/issues/926

**Possible drawbacks**
None I am aware of.
**Applicable issues**
N/A
**Additional information**
N/A