### PR TITLE
Load custom modules during initialisation

### DIFF
--- a/4.0/debian-9/Dockerfile
+++ b/4.0/debian-9/Dockerfile
@@ -10,6 +10,7 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
 # Install required system packages and dependencies
 RUN install_packages libc6
 RUN . ./libcomponent.sh && component_unpack "redis" "4.0.12-0" --checksum 71c0ee47ef69f43773993f86be5d32044e8ed30d899ee0de5075e086c1f44430
+RUN mkdir /docker-entrypoint-modules.d/
 
 COPY rootfs /
 RUN /prepare.sh

--- a/4.0/debian-9/docker-compose.yml
+++ b/4.0/debian-9/docker-compose.yml
@@ -10,8 +10,7 @@ services:
     ports:
       - '6379:6379'
     volumes:
-      - 'redis_data:/bitnami/redis/data'
-
+      - redis_data:/bitnami/redis/data
 volumes:
   redis_data:
     driver: local

--- a/4.0/debian-9/rootfs/setup.sh
+++ b/4.0/debian-9/rootfs/setup.sh
@@ -21,3 +21,5 @@ trap "redis_stop" EXIT
 am_i_root && ensure_user_exists "$REDIS_DAEMON_USER" "$REDIS_DAEMON_GROUP"
 # Ensure Redis is initialized
 redis_initialize
+# Allow loading custom Redis modules
+redis_custom_modules

--- a/4.0/ol-7/Dockerfile
+++ b/4.0/ol-7/Dockerfile
@@ -10,6 +10,7 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
 # Install required system packages and dependencies
 RUN install_packages glibc
 RUN . ./libcomponent.sh && component_unpack "redis" "4.0.12-0" --checksum 09e279009d6e8ed23451bf3988e9bf1baa9920e073e62da5d431d91c55d07dd7
+RUN mkdir /docker-entrypoint-modules.d/
 
 COPY rootfs /
 RUN /prepare.sh

--- a/4.0/ol-7/docker-compose.yml
+++ b/4.0/ol-7/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - '6379:6379'
     volumes:
-      - 'redis_data:/bitnami/redis/data'
+      - redis_data:/bitnami/redis/data
 
 volumes:
   redis_data:

--- a/4.0/ol-7/rootfs/setup.sh
+++ b/4.0/ol-7/rootfs/setup.sh
@@ -21,3 +21,5 @@ trap "redis_stop" EXIT
 am_i_root && ensure_user_exists "$REDIS_DAEMON_USER" "$REDIS_DAEMON_GROUP"
 # Ensure Redis is initialized
 redis_initialize
+# Allow loading custom Redis modules
+redis_custom_modules

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ $ docker-compose up -d
 
 # Configuration
 
+## Loading a custom module during initialization
+
+When the container is initialized, it will load the Redis modules with extensions .so located at `/docker-entrypoint-modules.d/`.
+
+In order to have your custom modules inside the docker image you can mount them as a volume.
+
 ## Disabling Redis commands
 
 For security reasons, you may want to disable some commands. You can specify them by using the following environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - '6379:6379'
     volumes:
-      - 'redis_data:/bitnami/redis'
+      - redis_data:/bitnami/redis
 
 volumes:
   redis_data:


### PR DESCRIPTION
**Description of the change**

This PR modifies Redis bash logic so it allows the user to mount/load custom modules during the initialization of the container.

- fixes https://github.com/bitnami/bitnami-docker-redis/issues/124
