### PR TITLE
Set replication announce-ip properly in swarm mode

### DIFF
--- a/4.0/centos-7/rootfs/libredis.sh
+++ b/4.0/centos-7/rootfs/libredis.sh
@@ -7,6 +7,7 @@
 # Load Generic Libraries
 . /libfile.sh
 . /liblog.sh
+. /libnet.sh
 . /libos.sh
 . /libservice.sh
 . /libvalidations.sh
@@ -283,7 +284,7 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
-    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-ip $(get_machine_ip)
     redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
 
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then

--- a/4.0/centos-7/rootfs/libredis.sh
+++ b/4.0/centos-7/rootfs/libredis.sh
@@ -283,6 +283,9 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
+    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
+
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then
         if [[ -n "$REDIS_PASSWORD" ]]; then
             redis_conf_set masterauth "$REDIS_PASSWORD"

--- a/4.0/debian-9/rootfs/libredis.sh
+++ b/4.0/debian-9/rootfs/libredis.sh
@@ -7,6 +7,7 @@
 # Load Generic Libraries
 . /libfile.sh
 . /liblog.sh
+. /libnet.sh
 . /libos.sh
 . /libservice.sh
 . /libvalidations.sh
@@ -283,7 +284,7 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
-    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-ip $(get_machine_ip)
     redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
 
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then

--- a/4.0/debian-9/rootfs/libredis.sh
+++ b/4.0/debian-9/rootfs/libredis.sh
@@ -283,6 +283,9 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
+    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
+
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then
         if [[ -n "$REDIS_PASSWORD" ]]; then
             redis_conf_set masterauth "$REDIS_PASSWORD"

--- a/4.0/ol-7/rootfs/libredis.sh
+++ b/4.0/ol-7/rootfs/libredis.sh
@@ -7,6 +7,7 @@
 # Load Generic Libraries
 . /libfile.sh
 . /liblog.sh
+. /libnet.sh
 . /libos.sh
 . /libservice.sh
 . /libvalidations.sh
@@ -283,7 +284,7 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
-    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-ip $(get_machine_ip)
     redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
 
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then

--- a/4.0/ol-7/rootfs/libredis.sh
+++ b/4.0/ol-7/rootfs/libredis.sh
@@ -283,6 +283,9 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
+    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
+
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then
         if [[ -n "$REDIS_PASSWORD" ]]; then
             redis_conf_set masterauth "$REDIS_PASSWORD"

--- a/5.0/centos-7/rootfs/libredis.sh
+++ b/5.0/centos-7/rootfs/libredis.sh
@@ -7,6 +7,7 @@
 # Load Generic Libraries
 . /libfile.sh
 . /liblog.sh
+. /libnet.sh
 . /libos.sh
 . /libservice.sh
 . /libvalidations.sh
@@ -283,7 +284,7 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
-    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-ip $(get_machine_ip)
     redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
 
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then

--- a/5.0/centos-7/rootfs/libredis.sh
+++ b/5.0/centos-7/rootfs/libredis.sh
@@ -283,6 +283,9 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
+    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
+
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then
         if [[ -n "$REDIS_PASSWORD" ]]; then
             redis_conf_set masterauth "$REDIS_PASSWORD"

--- a/5.0/debian-9/rootfs/libredis.sh
+++ b/5.0/debian-9/rootfs/libredis.sh
@@ -7,6 +7,7 @@
 # Load Generic Libraries
 . /libfile.sh
 . /liblog.sh
+. /libnet.sh
 . /libos.sh
 . /libservice.sh
 . /libvalidations.sh
@@ -283,7 +284,7 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
-    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-ip $(get_machine_ip)
     redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
 
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then

--- a/5.0/debian-9/rootfs/libredis.sh
+++ b/5.0/debian-9/rootfs/libredis.sh
@@ -283,6 +283,9 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
+    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
+
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then
         if [[ -n "$REDIS_PASSWORD" ]]; then
             redis_conf_set masterauth "$REDIS_PASSWORD"

--- a/5.0/ol-7/rootfs/libredis.sh
+++ b/5.0/ol-7/rootfs/libredis.sh
@@ -7,6 +7,7 @@
 # Load Generic Libraries
 . /libfile.sh
 . /liblog.sh
+. /libnet.sh
 . /libos.sh
 . /libservice.sh
 . /libvalidations.sh
@@ -283,7 +284,7 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
-    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-ip $(get_machine_ip)
     redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
 
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then

--- a/5.0/ol-7/rootfs/libredis.sh
+++ b/5.0/ol-7/rootfs/libredis.sh
@@ -283,6 +283,9 @@ redis_validate() {
 redis_configure_replication() {
     info "Configuring replication mode..."
 
+    redis_conf_set replica-announce-ip `hostname -i`
+    redis_conf_set replica-announce-port "$REDIS_MASTER_PORT_NUMBER"
+
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then
         if [[ -n "$REDIS_PASSWORD" ]]; then
             redis_conf_set masterauth "$REDIS_PASSWORD"


### PR DESCRIPTION
In swarm mode the detected IP address for slaves is not the IP that is addressable for redis.
This patch will set the IP based on the IP the container itself detects, thus working with docker's NAT.
