### PR TITLE
fix(passwords): support single quotes

### DIFF
--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -51,7 +51,7 @@ redis_conf_set() {
     value="${value//\?/\\?}"
     [[ "$value" = "" ]] && value="\"$value\""
 
-    replace_in_file "${REDIS_BASE_DIR}/etc/redis.conf" "^#*\s*${key} .*" "${key} ${value}" false
+    replace_in_file "${REDIS_BASE_DIR}/etc/redis.conf" "^#*\s*${key} .*" "${key} \"${value}\"" false
 }
 
 ########################

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -51,7 +51,7 @@ redis_conf_set() {
     value="${value//\?/\\?}"
     [[ "$value" = "" ]] && value="\"$value\""
 
-    replace_in_file "${REDIS_BASE_DIR}/etc/redis.conf" "^#*\s*${key} .*" "${key} ${value}" false
+    replace_in_file "${REDIS_BASE_DIR}/etc/redis.conf" "^#*\s*${key} .*" "${key} \"${value}\"" false
 }
 
 ########################


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Add `"` to the values that will be set in the `redis.conf` file

**Benefits**

We will be able to use `'` quotes in passwords.

**Possible drawbacks**

N/A

**Applicable issues**

- fixes #194

**Additional information**

N/A
