### PR TITLE
Always add tls-replication if TLS enabled

### DIFF
--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -243,6 +243,10 @@ redis_configure_replication() {
 
     redis_conf_set replica-announce-ip "${REDIS_REPLICA_IP:-$(get_machine_ip)}"
     redis_conf_set replica-announce-port "${REDIS_REPLICA_PORT:-$REDIS_MASTER_PORT_NUMBER}"
+    # Use TLS in the replication connections
+    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+        redis_conf_set tls-replication yes
+    fi
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then
         if [[ -n "$REDIS_PASSWORD" ]]; then
             redis_conf_set masterauth "$REDIS_PASSWORD"
@@ -265,10 +269,6 @@ redis_configure_replication() {
         local parameter="replicaof"
         [[ $(redis_major_version) -lt 5 ]] && parameter="slaveof"
         redis_conf_set "$parameter" "$REDIS_MASTER_HOST $REDIS_MASTER_PORT_NUMBER"
-    fi
-    # Configure replicas to use TLS for outgoing connections to the master
-    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-        redis_conf_set tls-replication yes
     fi
 }
 

--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -265,10 +265,10 @@ redis_configure_replication() {
         local parameter="replicaof"
         [[ $(redis_major_version) -lt 5 ]] && parameter="slaveof"
         redis_conf_set "$parameter" "$REDIS_MASTER_HOST $REDIS_MASTER_PORT_NUMBER"
-        # Configure replicas to use TLS for outgoing connections to the master
-        if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-            redis_conf_set tls-replication yes
-        fi
+    fi
+    # Configure replicas to use TLS for outgoing connections to the master
+    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+        redis_conf_set tls-replication yes
     fi
 }
 

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -243,6 +243,10 @@ redis_configure_replication() {
 
     redis_conf_set replica-announce-ip "${REDIS_REPLICA_IP:-$(get_machine_ip)}"
     redis_conf_set replica-announce-port "${REDIS_REPLICA_PORT:-$REDIS_MASTER_PORT_NUMBER}"
+    # Use TLS in the replication connections
+    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+        redis_conf_set tls-replication yes
+    fi
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then
         if [[ -n "$REDIS_PASSWORD" ]]; then
             redis_conf_set masterauth "$REDIS_PASSWORD"
@@ -265,10 +269,6 @@ redis_configure_replication() {
         local parameter="replicaof"
         [[ $(redis_major_version) -lt 5 ]] && parameter="slaveof"
         redis_conf_set "$parameter" "$REDIS_MASTER_HOST $REDIS_MASTER_PORT_NUMBER"
-    fi
-    # Configure replicas to use TLS for outgoing connections to the master
-    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-        redis_conf_set tls-replication yes
     fi
 }
 

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -265,10 +265,10 @@ redis_configure_replication() {
         local parameter="replicaof"
         [[ $(redis_major_version) -lt 5 ]] && parameter="slaveof"
         redis_conf_set "$parameter" "$REDIS_MASTER_HOST $REDIS_MASTER_PORT_NUMBER"
-        # Configure replicas to use TLS for outgoing connections to the master
-        if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-            redis_conf_set tls-replication yes
-        fi
+    fi
+    # Configure replicas to use TLS for outgoing connections to the master
+    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+        redis_conf_set tls-replication yes
     fi
 }
 


### PR DESCRIPTION
**Description of the change**
Right now `tls-replication` is applied only to `slave` and `replica` images. This leads to incorrect behavior with sentinel, when:

- Master went down (`docker-compose stop redis-master`)
- Sentinel(s) elected new Master from pool of Slaves
- Original master came back online and Sentinel reconfigured it as Slave (`docker-compose start redis-master`)
- When replication kicks in, the following appears in logs `Error accepting a client connection: error:1408F10B:SSL routines:ssl3_get_record:wrong version number`.

This PR enables `tls-replication` for all replica types

**Benefits**
- Removes the need of specifying extra run arguments when starting master in Docker
- Removes unnecessary `command: /opt/bitnami/scripts/redis/run.sh --tls-replication yes`

**Possible drawbacks**
N/A

**Applicable issues**
Similar issue in [bitnami/charts](https://github.com/bitnami/charts/issues/3045) and [pr](https://github.com/bitnami/charts/pull/3061/files) fixing it.

**Additional information**

compose file for reference
```yaml
version: "3"

services:
  redis-master:
    image: bitnami/redis:6.0.10
    volumes:
      - "./conf/certs:/opt/bitnami/redis/certs"
    environment:
      - REDIS_REPLICATION_MODE=master
      - REDIS_AOF_ENABLED=no
      - REDIS_ALLOW_REMOTE_CONNECTIONS=yes
      - ALLOW_EMPTY_PASSWORD=yes
      - REDIS_TLS_ENABLED=yes
      - REDIS_TLS_PORT=16300
      - REDIS_TLS_AUTH_CLIENTS=no
      - REDIS_TLS_CERT_FILE=/opt/bitnami/redis/certs/redis.crt
      - REDIS_TLS_KEY_FILE=/opt/bitnami/redis/certs/redis.key
      - REDIS_TLS_CA_FILE=/opt/bitnami/redis/certs/ca.crt
    ports:
      - "16300:16300"
    networks: 
      default:
        aliases:
          - redis.master.host
  redis-slave:
    image: bitnami/redis:6.0.10
    volumes:
      - "./conf/certs:/opt/bitnami/redis/certs"
    environment:
      - ALLOW_EMPTY_PASSWORD=yes
      - REDIS_ALLOW_REMOTE_CONNECTIONS=yes
      - REDIS_AOF_ENABLED=no
      - REDIS_REPLICATION_MODE=slave
      - REDIS_MASTER_HOST=redis.master.host
      - REDIS_MASTER_PORT_NUMBER=16300
      - REDIS_REPLICA_PORT=16400
      - REDIS_TLS_ENABLED=yes
      - REDIS_TLS_PORT=16400
      - REDIS_TLS_AUTH_CLIENTS=no
      - REDIS_TLS_CERT_FILE=/opt/bitnami/redis/certs/redis.crt
      - REDIS_TLS_KEY_FILE=/opt/bitnami/redis/certs/redis.key
      - REDIS_TLS_CA_FILE=/opt/bitnami/redis/certs/ca.crt
    ports:
      - "16400:16400"
    depends_on:
      - redis-master
    networks: 
      default:
        aliases:
          - redis.slave.host
  redis-sentinel:  
    image: bitnami/redis-sentinel:6.0.10
    volumes:
      - "./conf/certs:/opt/bitnami/redis/certs"
    environment:
      - ALLOW_EMPTY_PASSWORD=yes
      - REDIS_ALLOW_REMOTE_CONNECTIONS=yes
      - REDIS_MASTER_SET=le-master
      - REDIS_MASTER_HOST=redis.master.host
      - REDIS_MASTER_PORT_NUMBER=16300
      - REDIS_SENTINEL_TLS_ENABLED=yes
      - REDIS_SENTINEL_TLS_PORT_NUMBER=16500
      - REDIS_SENTINEL_TLS_AUTH_CLIENTS=no
      - REDIS_SENTINEL_TLS_CERT_FILE=/opt/bitnami/redis/certs/redis.crt
      - REDIS_SENTINEL_TLS_KEY_FILE=/opt/bitnami/redis/certs/redis.key
      - REDIS_SENTINEL_TLS_CA_FILE=/opt/bitnami/redis/certs/ca.crt
      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=5000
      - REDIS_SENTINEL_FAILOVER_TIMEOUT=5000
      - REDIS_SENTINEL_QUORUM=1
    ports:
      - "16500:16500"
    depends_on:
      - redis-master
      - redis-slave
    networks: 
      default:
        aliases:
          - redis.sentinel.host

volumes:
  conf:

networks: 
  default:
      external: 
          name: my-net
```