### PR TITLE
Add REDIS_PORT_NUMBER usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ services:
 
 ## Setting up a standalone instance
 
-By default, this image is set up to launch Redis(TM) in standalone mode on the default port number of 6379. Should you need to change this behaviour, setting the `REDIS_PORT_NUMBER` environment variable will modify the port number. This is not to be confused with `REDIS_MASTER_PORT_NUMBER` or `REDIS_REPLICA_PORT` environment variables that are applicable in replication mode.
+By default, this image is set up to launch Redis(TM) in standalone mode on port 6379. Should you need to change this behavior, setting the `REDIS_PORT_NUMBER` environment variable will modify the port number. This is not to be confused with `REDIS_MASTER_PORT_NUMBER` or `REDIS_REPLICA_PORT` environment variables that are applicable in replication mode.
 
 ```console
 $ docker run --name redis -e REDIS_PORT_NUMBER=7000 -p 7000:7000 bitnami/redis:latest

--- a/README.md
+++ b/README.md
@@ -290,6 +290,28 @@ services:
   ...
 ```
 
+## Setting up a standalone instance
+
+By default, this image is set up to launch Redis(TM) in standalone mode on the default port number of 6379. Should you need to change this behaviour, setting the `REDIS_PORT_NUMBER` environment variable will modify the port number. This is not to be confused with `REDIS_MASTER_PORT_NUMBER` or `REDIS_REPLICA_PORT` environment variables that are applicable in replication mode.
+
+```console
+$ docker run --name redis -e REDIS_PORT_NUMBER=7000 -p 7000:7000 bitnami/redis:latest
+```
+
+Alternatively, modify the [`docker-compose.yml`](https://github.com/bitnami/bitnami-docker-redis/blob/master/docker-compose.yml) file present in this repository:
+
+```yaml
+services:
+  redis:
+  ...
+    environment:
+      - REDIS_PORT_NUMBER=7000
+    ...
+    ports:
+      - '7000:7000'
+  ....
+```
+
 ## Setting up replication
 
 A [replication](http://redis.io/topics/replication) cluster can easily be setup with the Bitnami Redis(TM) Docker Image using the following environment variables:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Adds documentation on the usage of the `REDIS_PORT_NUMBER` env variable to the repo README file. Documentation only, no code change. Notates that it should not be confused with the replication mode env variables.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Allows those seeking to launch a standalone mode instance (e.g. for development) to quickly understand how to change the default port number if so desired. 

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

None?

<!-- Describe any known limitations with your change -->

**Applicable issues**

#205 

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
