### PR TITLE
Add REDIS_ACLFILE env variable

### DIFF
--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -402,5 +402,8 @@ redis_configure_default() {
         if [[ -n "$REDIS_DISABLE_COMMANDS" ]]; then
             redis_disable_unsafe_commands
         fi
+        if [[ -n "$REDIS_ACLFILE" ]]; then
+            redis_conf_set aclfile "$REDIS_ACLFILE"
+        fi
     fi
 }

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-env.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-env.sh
@@ -47,6 +47,7 @@ redis_env_vars=(
     REDIS_SENTINEL_HOST
     REDIS_SENTINEL_PORT_NUMBER
     REDIS_TLS_PORT
+    REDIS_ACLFILE
 )
 for env_var in "${redis_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -95,6 +96,7 @@ export REDIS_EXTRA_FLAGS="${REDIS_EXTRA_FLAGS:-}"
 export ALLOW_EMPTY_PASSWORD="${ALLOW_EMPTY_PASSWORD:-no}"
 export REDIS_PASSWORD="${REDIS_PASSWORD:-}"
 export REDIS_MASTER_PASSWORD="${REDIS_MASTER_PASSWORD:-}"
+export REDIS_ACLFILE="${REDIS_ACLFILE:-}"
 
 # TLS settings
 export REDIS_TLS_ENABLED="${REDIS_TLS_ENABLED:-no}"

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -402,5 +402,8 @@ redis_configure_default() {
         if [[ -n "$REDIS_DISABLE_COMMANDS" ]]; then
             redis_disable_unsafe_commands
         fi
+        if [[ -n "$REDIS_ACLFILE" ]]; then
+            redis_conf_set aclfile "$REDIS_ACLFILE"
+        fi
     fi
 }

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-env.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-env.sh
@@ -47,6 +47,7 @@ redis_env_vars=(
     REDIS_SENTINEL_HOST
     REDIS_SENTINEL_PORT_NUMBER
     REDIS_TLS_PORT
+    REDIS_ACLFILE
 )
 for env_var in "${redis_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -95,6 +96,7 @@ export REDIS_EXTRA_FLAGS="${REDIS_EXTRA_FLAGS:-}"
 export ALLOW_EMPTY_PASSWORD="${ALLOW_EMPTY_PASSWORD:-no}"
 export REDIS_PASSWORD="${REDIS_PASSWORD:-}"
 export REDIS_MASTER_PASSWORD="${REDIS_MASTER_PASSWORD:-}"
+export REDIS_ACLFILE="${REDIS_ACLFILE:-}"
 
 # TLS settings
 export REDIS_TLS_ENABLED="${REDIS_TLS_ENABLED:-no}"

--- a/README.md
+++ b/README.md
@@ -293,6 +293,26 @@ services:
   ...
 ```
 
+### Enabling Access Control List
+Redis(TM) offers [ACL](https://redis.io/topics/acl) since 6.0 which allows certain connections to be limited in terms of the commands that can be executed and the keys that can be accessed. We strongly recommend enabling ACL in production by specifiying the `REDIS_ACLFILE`.
+
+```console
+$ docker run -name redis -e REDIS_ACLFILE=/opt/bitnami/redis/mounted-etc/users.acl -v /path/to/users.acl:/opt/bitnami/redis/mounted-etc/users.acl bitnami/redis:latest
+```
+
+Alternatively, modify the [`docker-compose.yml`](https://github.com/bitnami/bitnami-docker-redis/blob/master/docker-compose.yml) file present in this repository:
+
+```yaml
+services:
+  redis:
+  ...
+    environment:
+      - REDIS_ACLFILE=/opt/bitnami/redis/mounted-etc/users.acl
+    volumes:
+      - /path/to/users.acl:/opt/bitnami/redis/mounted-etc/users.acl
+  ...
+```
+
 ### Setting up a standalone instance
 
 By default, this image is set up to launch Redis(TM) in standalone mode on port 6379. Should you need to change this behavior, setting the `REDIS_PORT_NUMBER` environment variable will modify the port number. This is not to be confused with `REDIS_MASTER_PORT_NUMBER` or `REDIS_REPLICA_PORT` environment variables that are applicable in replication mode.


### PR DESCRIPTION
**Description of the change**

Added `REDIS_ACLFILE` which allows specifying of `aclfile` in redis.conf.
- Fixes https://github.com/bitnami/bitnami-docker-redis/issues/223

Benefits:
Allow quicker access to implement ACL.

Limitation(s):
- Available from Redis 6.0 and up
- Does not add logic to check if files exists. Redis will throw an error and fail to start if the user did not mount the file to the container.

