### PR TITLE
fix: only check passphrase file if set

### DIFF
--- a/6.2/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/6.2/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -220,7 +220,7 @@ redis_validate() {
         elif [[ ! -f "$REDIS_TLS_KEY_FILE" ]]; then
             print_validation_error "The private key file in the specified path ${REDIS_TLS_KEY_FILE} does not exist"
         fi
-        if [[ ! -f "$REDIS_TLS_KEY_FILE_PASS" ]]; then
+        if [[ -n "$REDIS_TLS_KEY_FILE_PASS" ]] &&[[ ! -f "$REDIS_TLS_KEY_FILE_PASS" ]]; then
             print_validation_error "The passphrase for the private key file in the specified path ${REDIS_TLS_KEY_FILE_PASS} does not exist"
         fi
         if [[ -z "$REDIS_TLS_CA_FILE" ]]; then

--- a/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -220,7 +220,7 @@ redis_validate() {
         elif [[ ! -f "$REDIS_TLS_KEY_FILE" ]]; then
             print_validation_error "The private key file in the specified path ${REDIS_TLS_KEY_FILE} does not exist"
         fi
-        if [[ ! -f "$REDIS_TLS_KEY_FILE_PASS" ]]; then
+        if [[ -n "$REDIS_TLS_KEY_FILE_PASS" ]] &&[[ ! -f "$REDIS_TLS_KEY_FILE_PASS" ]]; then
             print_validation_error "The passphrase for the private key file in the specified path ${REDIS_TLS_KEY_FILE_PASS} does not exist"
         fi
         if [[ -z "$REDIS_TLS_CA_FILE" ]]; then


### PR DESCRIPTION
**Description of the change**

Requires that `REDIS_TLS_KEY_FILE_PASS` environment variable is set to check for the existence of the file.

**Benefits**

If this setting is not present (likely the case for almost all existing uses of this image, since it was [only added a few days ago](https://github.com/bitnami/bitnami-docker-redis/commit/d2116d9cc2203875284a231e2ce34f30096a2da2), and a valid configuration if there is no passphrase on the key file), the image unconditionally checks if the file exists. The `""` file never exists, and not setting this value prevents the image from starting.

**Possible drawbacks**

None known.

**Applicable issues**

The following is a brief example of the Pod state without this change and our existing configuration:

```
$ kubectl describe po -n 5840c50b-f8a0-492d-ba65-7b3152cf59ad tlspass-54b5d95f48-g6v6t | grep REDIS_
      REDIS_TLS_ENABLED:    true
      REDIS_TLS_PORT:       6379
      REDIS_TLS_CA_FILE:    /opt/certs/tls.crt
      REDIS_TLS_CERT_FILE:  /opt/certs/tls.crt
      REDIS_TLS_KEY_FILE:   /opt/certs/tls.key
      REDIS_PASSWORD:       garbage
$ kubectl logs -n 5840c50b-f8a0-492d-ba65-7b3152cf59ad tlspass-54b5d95f48-g6v6t              
redis 17:20:01.68 
redis 17:20:01.68 Welcome to the Bitnami redis container
redis 17:20:01.68 Subscribe to project updates by watching https://github.com/bitnami/containers
redis 17:20:01.68 Submit issues and feature requests at https://github.com/bitnami/containers/issues
redis 17:20:01.68 
redis 17:20:01.68 INFO  ==> ** Starting Redis setup **
redis 17:20:01.69 ERROR ==> The passphrase for the private key file in the specified path  does not exist
$ kubectl get po -n 5840c50b-f8a0-492d-ba65-7b3152cf59ad tlspass-54b5d95f48-g6v6t    
NAME                       READY   STATUS             RESTARTS      AGE
tlspass-54b5d95f48-g6v6t   0/1     CrashLoopBackOff   8 (34s ago)   16m
```
